### PR TITLE
Improve Empty response handling in Either and Domain implementations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,14 +1,14 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 
 import PackageDescription
 
 let package = Package(
     name: "RetroSwift",
     platforms: [
-        .macOS("10.15"),
-        .iOS("13.0"),
-        .tvOS("13.0"),
-        .watchOS("6.0")
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
         .library(
@@ -21,7 +21,6 @@ let package = Package(
             path: "RetroSwift"),
         .testTarget(
             name: "RetroSwiftTests",
-            // FIXME: Linter to be added
             dependencies: ["RetroSwift"],
             path: "RetroSwiftTests")
     ]

--- a/RetroSwift/ApiContractDescription/Domain/Domain.swift
+++ b/RetroSwift/ApiContractDescription/Domain/Domain.swift
@@ -37,7 +37,7 @@ open class Domain {
         let responseData = try operationResult.response.get()
 
         if responseData.isEmpty {
-            if Response.self is Empty.Type || Domain.isEitherWithEmptyResponse(Response.self) {
+            if Response.self is EmptyResponseDecodable.Type || Domain.isEitherWithEmptyResponse(Response.self) {
                 return try JSONDecoder().decode(Response.self, from: Domain.emptyJsonData)
             }
         }
@@ -47,10 +47,5 @@ open class Domain {
 }
 
 private extension Domain {
-    static let emptyJsonData: Data = {
-        guard let data = "{}".data(using: .utf8) else {
-            return Data()
-        }
-        return data
-    }()
+    static let emptyJsonData = Data("{}".utf8)
 }

--- a/RetroSwift/ApiContractDescription/Domain/Domain.swift
+++ b/RetroSwift/ApiContractDescription/Domain/Domain.swift
@@ -36,11 +36,21 @@ open class Domain {
         let operationResult = try await transport.sendRequest(with: requestParams)
         let responseData = try operationResult.response.get()
 
-        if responseData.isEmpty, Response.self is Empty.Type {
-            // swiftlint:disable:next force_cast
-            return Empty() as! Response
-        } else {
-            return try JSONDecoder().decode(Response.self, from: responseData)
+        if responseData.isEmpty {
+            if Response.self is Empty.Type || Domain.isEitherWithEmptyResponse(Response.self) {
+                return try JSONDecoder().decode(Response.self, from: Domain.emptyJsonData)
+            }
         }
+
+        return try JSONDecoder().decode(Response.self, from: responseData)
     }
+}
+
+private extension Domain {
+    static let emptyJsonData: Data = {
+        guard let data = "{}".data(using: .utf8) else {
+            return Data()
+        }
+        return data
+    }()
 }

--- a/RetroSwift/ApiContractDescription/Domain/ResponseTypes/Domain.Either.swift
+++ b/RetroSwift/ApiContractDescription/Domain/ResponseTypes/Domain.Either.swift
@@ -20,7 +20,7 @@ extension Domain {
         guard let eitherType = type as? EitherCheckable.Type else {
             return false
         }
-        return eitherType.responseType is Empty.Type
+        return eitherType.responseType is EmptyResponseDecodable.Type
     }
 }
 
@@ -28,8 +28,9 @@ public extension Domain.Either {
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
-        if Response.self is Domain.Empty.Type {
-            if let errorValue = try? container.decode(ErrorResponse.self) {
+        if Response.self is EmptyResponseDecodable.Type {
+            if let errorValue = try? container.decode(ErrorResponse.self),
+               !errorValue.isEmptyErrorResponse {
                 self = .errorResponse(errorValue)
                 return
             }
@@ -43,5 +44,19 @@ public extension Domain.Either {
         }
         let errorValue = try container.decode(ErrorResponse.self)
         self = .errorResponse(errorValue)
+    }
+}
+
+public protocol EmptyErrorCheckable {
+    var isEmptyErrorResponse: Bool { get }
+}
+
+extension EmptyErrorCheckable {
+    public var isEmptyErrorResponse: Bool { false }
+}
+
+extension Decodable {
+    var isEmptyErrorResponse: Bool {
+        (self as? EmptyErrorCheckable)?.isEmptyErrorResponse ?? false
     }
 }

--- a/RetroSwift/ApiContractDescription/Domain/ResponseTypes/Domain.Either.swift
+++ b/RetroSwift/ApiContractDescription/Domain/ResponseTypes/Domain.Either.swift
@@ -1,21 +1,47 @@
 import Foundation
 
-extension Domain {
-    public enum Either<Response: Decodable, ErrorResponse: Decodable>: Decodable {
+public extension Domain {
+    enum Either<Response: Decodable, ErrorResponse: Decodable>: Decodable {
         case response(Response)
         case errorResponse(ErrorResponse)
     }
 }
 
-extension Domain.Either {
-    public init(from decoder: Decoder) throws {
+private protocol EitherCheckable {
+    static var responseType: Any.Type { get }
+}
+
+extension Domain.Either: EitherCheckable {
+    static var responseType: Any.Type { Response.self }
+}
+
+extension Domain {
+    static func isEitherWithEmptyResponse(_ type: Any.Type) -> Bool {
+        guard let eitherType = type as? EitherCheckable.Type else {
+            return false
+        }
+        return eitherType.responseType is Empty.Type
+    }
+}
+
+public extension Domain.Either {
+    init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
+
+        if Response.self is Domain.Empty.Type {
+            if let errorValue = try? container.decode(ErrorResponse.self) {
+                self = .errorResponse(errorValue)
+                return
+            }
+            self = try .response(container.decode(Response.self))
+            return
+        }
 
         if let value = try? container.decode(Response.self) {
             self = .response(value)
-        } else {
-            let errorValue = try container.decode(ErrorResponse.self)
-            self = .errorResponse(errorValue)
+            return
         }
+        let errorValue = try container.decode(ErrorResponse.self)
+        self = .errorResponse(errorValue)
     }
 }

--- a/RetroSwift/ApiContractDescription/Domain/ResponseTypes/Domain.Empty.swift
+++ b/RetroSwift/ApiContractDescription/Domain/ResponseTypes/Domain.Empty.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+public protocol EmptyResponseDecodable: Decodable {
+    init()
+}
+
 extension Domain {
-    public struct Empty: Decodable { }
+    public struct Empty: EmptyResponseDecodable {
+        public init() {}
+    }
 }


### PR DESCRIPTION
Improve Empty response handling in Either and Domain implementations

This commit enhances the way to handle empty responses, particularly for Either types.

Key Changes:
- Implement type-safe Either response checking using EitherCheckable protocol
- Replace string-based type checking with Swift's native type system
- Add safe empty JSON data handling without force unwrapping
- Unify empty response handling for both Empty and Either<Empty, ErrorResponse> types
- Improve decoder implementation to handle empty responses consistently

Technical Details:
- Add EitherCheckable protocol for type-safe Either response type inspection
- Implement static responseType property to access generic type information
- Add safe initialization for empty JSON data
- Consolidate empty response handling logic in Domain.perform